### PR TITLE
Firewall Fix for Linux, Windows & Mac

### DIFF
--- a/dm-cmd/manager/firewall/protocol.go
+++ b/dm-cmd/manager/firewall/protocol.go
@@ -1,0 +1,56 @@
+package firewall
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ProtocolClass represents a network protocol classification.
+type ProtocolClass string
+
+const (
+	TCP ProtocolClass = "tcp"
+	UDP ProtocolClass = "udp"
+	ANY ProtocolClass = "any"
+	ALL ProtocolClass = "all"
+)
+
+// Protocol classification mapping.
+var protocolClassMap = map[string]ProtocolClass{
+	"any":      ANY,
+	"all":      ALL,
+	"ssh":      TCP,
+	"ftp":      TCP,
+	"scp":      TCP,
+	"sftp":     TCP,
+	"rtp":      TCP,
+	"rtcp":     TCP,
+	"telnet":   TCP,
+	"http":     TCP,
+	"https":    TCP,
+	"smtp":     TCP,
+	"imap":     TCP,
+	"pop":      TCP,
+	"pop3":     TCP,
+	"mysql":    TCP,
+	"postgres": TCP,
+	"redis":    TCP,
+	"mongodb":  TCP,
+	"ldap":     TCP,
+	"snmp":     UDP,
+	"dhcp":     UDP,
+	"ntp":      UDP,
+	"tftp":     UDP,
+	"syslog":   UDP,
+	"dns":      UDP,
+	"gq":       UDP,
+}
+
+// getProtocolClass returns the ProtocolClass for a given protocol name.
+func getProtocolClass(protocol string) (string, error) {
+	protocol = strings.ToLower(protocol)
+	if class, exists := protocolClassMap[protocol]; exists {
+		return string(class), nil
+	}
+	return string(ANY), fmt.Errorf("protocol '%s' is not recognized", protocol)
+}

--- a/dm.go
+++ b/dm.go
@@ -370,7 +370,6 @@ func firewallToMap(output string) (map[string]string, error) {
 func parseFirewallRulesForLinux(output string) map[string]string {
 	var ruleMap map[string]string
 	lines := strings.Split(output, "\n")
-	fmt.Println(lines[2])
 	if len(lines) >= 3 {
 		ruleMap = make(map[string]string)
 		line := lines[2]


### PR DESCRIPTION
## Below are the modified changes:

### Linux fixes for Firewall:

1. **Corner cases**  -  Handling rule already exists error by continueing.
2. **Supported protocols are tcp and udp**, so created a mapper for the same.

### Windows fixes for Firewall:

1. **Protocols** : Instead of using the application layer name like SSH, HTTP etc, use the transport layer protocol, which will be TCP, UDP, ALL or ANY
2. **Corner cases : [a]** rule already exists cases, **[b]** error handling for exit without any error

### Mac fixes for Firewall:

1. **validateFirewallInput**: Modified input validation rules, as the ip and port where not being checked correctly.
2. **getFirewallByAnchorName**: Refactored the function to match by regex and retrieve the rules.

### Common fixes/changes:
1. **Chain name logic change to remove kitecyber**-{operation}-{direction} and keep only {protocol}-{ip_address}{host}, because of character constraint to 29 chars only.
2. **Proto mapper implementation** - To retrieve proto like TCP, UDP, ANY, ALL where all the possible values are classified under groups, like SSH, FTP under TCP and so on and so forth.